### PR TITLE
Add showDiff option to the base Snapshot class

### DIFF
--- a/src/AbstractSnapshot.php
+++ b/src/AbstractSnapshot.php
@@ -268,6 +268,10 @@ class AbstractSnapshot extends Snapshot
                 return;
             }
 
+            if ($this->showDiff) {
+                throw $exception;
+            }
+
             $this->fail($exception->getMessage());
         }
     }


### PR DESCRIPTION
Since the last change to `AbstractSnapshot.php` codeception has added a `showDiff` option which is useful to show the actual change. See https://github.com/Codeception/Codeception/pull/5930.

It could be nice to add a call to `shouldShowDiffOnFail`  in the `SnapshotAssertions` class, because arguably showing the diff in the log is the only way to see what went wrong in CI. But, I didn't include that here, because I didn't want to bloat this PR. I can make another PR for that though.