### PR TITLE
Fix multiple assertions on same method

### DIFF
--- a/src/AbstractSnapshot.php
+++ b/src/AbstractSnapshot.php
@@ -160,7 +160,8 @@ class AbstractSnapshot extends Snapshot
         $function .= $dataSetName;
 
         if (isset(static::$counters[$class][$function])) {
-            return static::$counters[$class][$function]++;
+            static::$counters[$class][$function]++;
+            return static::$counters[$class][$function];
         }
         static::$counters[$class][$function] = 0;
         return 0;


### PR DESCRIPTION
On an webdriver test, this would fail:

```php
public function Foo {
  $this->assertMatchesStringSnapshot('bar');
  $this->assertMatchesStringSnapshot('baz');
}
```

Saying that "baz" is not equal expected "bar". This happens because of a bug to how the filenames are generated, that should increment a counter for multiple tests:

- FooCest__doFoo__0.snapshot.txt
- FooCest__doFoo__1.snapshot.txt (with the bug, both are 0)

 I'm opening this PR from GitHub UI.

Fixes https://github.com/lucatume/codeception-snapshot-assertions/issues/7