### PR TITLE
Fix snapshot file name building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Snapshot file naming issue when using assertions in a trait.
+
 ## [1.3.0] - 2024-12-08
 
 ### Changed

--- a/tests/unit/tad/Codeception/SnapshotAssertions/ConfigurationTest.php
+++ b/tests/unit/tad/Codeception/SnapshotAssertions/ConfigurationTest.php
@@ -155,8 +155,7 @@ class ConfigurationTest extends Unit
      *
      * @test
      */
-    public function should_prepend_the_version_string_to_the_snapshot_file_name_if_set_in_the_codeception_configuration(
-    )
+    public function should_prepend_the_version_string_to_the_snapshot_file_name_if_set_in_the_codeception_configuration()
     {
         $this->mockCodeceptionConfig([
             'snapshot' => [

--- a/tests/unit/tad/Codeception/SnapshotAssertions/CustomAssertionTraitUsingCustomAssertionTrait.php
+++ b/tests/unit/tad/Codeception/SnapshotAssertions/CustomAssertionTraitUsingCustomAssertionTrait.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace tad\Codeception\SnapshotAssertions;
+
+trait CustomAssertionTraitUsingCustomAssertionTrait
+{
+    use CustomSnapshotAssertionTrait;
+
+    protected function assertMatchesByAnotherCriteria($data)
+    {
+        $this->assertMatchesCustomSnapshot($data);
+    }
+}

--- a/tests/unit/tad/Codeception/SnapshotAssertions/CustomSnapshotAssertionTrait.php
+++ b/tests/unit/tad/Codeception/SnapshotAssertions/CustomSnapshotAssertionTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace tad\Codeception\SnapshotAssertions;
+
+use tad\Codeception\SnapshotAssertions\SnapshotAssertions;
+
+trait CustomSnapshotAssertionTrait
+{
+    use SnapshotAssertions;
+
+    protected function assertMatchesCustomSnapshot($data)
+    {
+        $this->assertMatchesStringSnapshot($data);
+    }
+}

--- a/tests/unit/tad/Codeception/SnapshotAssertions/TraitTest.php
+++ b/tests/unit/tad/Codeception/SnapshotAssertions/TraitTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace tad\Codeception\SnapshotAssertions;
+
+class TraitTest extends BaseTestCase
+{
+    use CustomSnapshotAssertionTrait;
+    use CustomAssertionTraitUsingCustomAssertionTrait;
+
+    protected array $unlinkAfter = [
+        __DIR__ . '/__snapshots__/TraitTest__should_correctly_name_snapshot_files__0.snapshot.txt',
+        __DIR__ . '/__snapshots__/TraitTest__should_correctly_name_snapshot_files__1.snapshot.txt',
+        __DIR__ . '/__snapshots__/TraitTest__should_correctly_name_snapshot_files_with_dataset__one__0.snapshot.txt',
+        __DIR__ . '/__snapshots__/TraitTest__should_correctly_name_snapshot_files_with_dataset__two__0.snapshot.txt',
+        __DIR__ . '/__snapshots__/TraitTest__should_correctly_name_snapshot_files_with_dataset__three__0.snapshot.txt',
+        __DIR__ . "/__snapshots__/TraitTest__should_correctly_name_snapshot_files_with_dataset_when_trait_using_trait__one__0.snapshot.txt",
+        __DIR__ . "/__snapshots__/TraitTest__should_correctly_name_snapshot_files_with_dataset_when_trait_using_trait__two__0.snapshot.txt",
+        __DIR__ . "/__snapshots__/TraitTest__should_correctly_name_snapshot_files_with_dataset_when_trait_using_trait__three__0.snapshot.txt",
+    ];
+
+    /**
+     * @before
+     */
+    public function removeSnapshots(): void
+    {
+        $this->unlinkFiles();
+    }
+
+    /**
+     * It should correctly name snapshot files
+     *
+     * @test
+     */
+    public function should_correctly_name_snapshot_files(): void
+    {
+        // The snapshot does not exist, and it will be created.
+        $this->assertMatchesCustomSnapshot('custom');
+        // The snapshot does not exist, and it will be created.
+        $this->assertMatchesByAnotherCriteria('custom');
+
+        $this->assertFileExists(__DIR__ . '/__snapshots__/TraitTest__should_correctly_name_snapshot_files__0.snapshot.txt');
+        $this->assertFileExists(__DIR__ . '/__snapshots__/TraitTest__should_correctly_name_snapshot_files__1.snapshot.txt');
+    }
+
+    public static function names(): array
+    {
+        return [
+            'one'   => [ 'one' ],
+            'two'   => [ 'two' ],
+            'three' => [ 'three' ]
+        ];
+    }
+
+    /**
+     * It should correctly name snapshot files with dataset
+     *
+     * @dataProvider names
+     * @test
+     */
+    public function should_correctly_name_snapshot_files_with_dataset(string $name):void
+    {
+        // The snapshot does not exist, and it will be created.
+        $this->assertMatchesCustomSnapshot('custom');
+
+        $this->assertFileExists(
+            __DIR__ . "/__snapshots__/TraitTest__should_correctly_name_snapshot_files_with_dataset__{$name}__0.snapshot.txt"
+        );
+    }
+
+    /**
+     * Should correctly name snapshot files with dataset when trait using trait
+     *
+     * @dataProvider names
+     * @test
+     */
+    public function should_correctly_name_snapshot_files_with_dataset_when_trait_using_trait(string $name):void
+    {
+        // The snapshot does not exist, and it will be created.
+        // The snapshot does not exist, and it will be created.
+        $this->assertMatchesCustomSnapshot('custom');
+
+        $this->assertFileExists(
+            __DIR__ . "/__snapshots__/TraitTest__should_correctly_name_snapshot_files_with_dataset_when_trait_using_trait__{$name}__0.snapshot.txt"
+        );
+    }
+}


### PR DESCRIPTION
This fixes the issue raised in #17 and #18 by removing the need for a custom class to get the snapshot file name right.

