### PR TITLE
Replace spaces with _ in dataset names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2025-07-01
+
+### Changed
+
+- White spaces in names of datasets will be converted to underscores to improve the snapshot copy-and-paste-ability.
+
 ## [1.3.1] - 2025-06-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -378,5 +378,3 @@ class SvgTest extends Unit {
 	}
 }
 ```
-
-

--- a/src/AbstractSnapshot.php
+++ b/src/AbstractSnapshot.php
@@ -127,6 +127,8 @@ class AbstractSnapshot extends Snapshot
             $testCase = $match['object'];
             $dataName = $this->getDataName($testCase);
             if ($dataName !== '') {
+                // Replace white spaces with underscore.
+                $dataName = preg_replace('/\s+/', '_', $dataName);
                 $dataSetFrag = '__' . $dataName;
             }
         }

--- a/tests/unit/tad/Codeception/SnapshotAssertions/DataSetNamingTest.php
+++ b/tests/unit/tad/Codeception/SnapshotAssertions/DataSetNamingTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace tad\Codeception\SnapshotAssertions;
+
+class DataSetNamingTest extends BaseTestCase
+{
+    use SnapshotAssertions;
+
+    /**
+     * @before
+     */
+    public function cleanUp()
+    {
+        $this->unlinkFiles();
+    }
+
+    public static function stringSnapshotDataProvider():array
+    {
+        return [
+            'snake_case_dataset' => ['snake_case', 'snake_case_dataset'],
+            'camelCaseDataset' => ['camelCase', 'camelCaseDataset'],
+            'PascalCaseDataset' => ['PascalCase', 'PascalCaseDataset'],
+            'kebab-case-dataset' => ['kebab-case', 'kebab-case-dataset'],
+            'spaces between words dataset' => ['spaces_between_words', 'spaces_between_words_dataset'],
+            'double  spaces  between  words  dataset' => ['double_spaces_between_words_dataset', 'double_spaces_between_words_dataset'],
+        ];
+    }
+
+    /**
+     * Should name snapshot files with slugs
+     *
+     * @test
+     * @dataProvider stringSnapshotDataProvider
+     */
+    public function should_name_snapshot_files_with_slugs(string $testString, string $expected): void
+    {
+        $expectedSnapshotFileName = __DIR__ . '/__snapshots__/DataSetNamingTest__should_name_snapshot_files_with_slugs__' . $expected . '__0.snapshot.txt';
+        $this->unlinkAfter[]= $expectedSnapshotFileName;
+
+        $this->assertMatchesStringSnapshot('test');
+
+        $this->assertFileExists($expectedSnapshotFileName);
+    }
+}


### PR DESCRIPTION
When building the snapshot file name, replace white spaces found in dataset names with `_` to improve machine parsing (copy-and-paste, link from terminal) while keeping human-readable format in the data provider code.
