### PR TITLE
Space to _ in data set name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2025-07-01
+
+### Changed
+
+- White spaces in names of datasets will be converted to underscores to improve the snapshot copy-and-paste-ability.
+
 ## [0.4.1] - 2025-06-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ class WidgetTest extends Codeception\TestCase\Test
 
 ## Requirements
 
-The package is based on the snapshot support added in Codeception since version `2.5.0`, as such the library requirments are:
+The package is based on the snapshot support added in Codeception since version `2.5.0`, as such the library requirements are:
 * PHP 5.6+
 * Codeception 2.5+
 

--- a/src/AbstractSnapshot.php
+++ b/src/AbstractSnapshot.php
@@ -155,6 +155,7 @@ class AbstractSnapshot extends Snapshot
                 $testCase = $match['object'];
                 $dataName = $this->getDataName($testCase);
                 if ($dataName !== '') {
+                    $dataName = preg_replace('/\\s+/', '_', $dataName);
                     $dataSetFrag = '__' . $dataName;
                 }
             }
@@ -196,7 +197,7 @@ class AbstractSnapshot extends Snapshot
     }
 
     /**
-     * Returns the counter, an integer, for a class, methdo and data-set combination.
+     * Returns the counter, an integer, for a class, method and data-set combination.
      *
      * @param  string  $class        The class to return the counter for.
      * @param  string  $function     The function/method to return the counter for.
@@ -340,7 +341,7 @@ class AbstractSnapshot extends Snapshot
     /**
      * Whether the data is empty or not.
      *
-     * Extending classes can override this method to implement more sofisticated checks.
+     * Extending classes can override this method to implement more sophisticated checks.
      *
      * @param  mixed  $data  The data to check.
      *

--- a/src/StringSnapshot.php
+++ b/src/StringSnapshot.php
@@ -68,7 +68,7 @@ class StringSnapshot extends AbstractSnapshot
     /**
      *
      *
-     * @param  mixed  $data  The data to check for emptyness.
+     * @param  mixed  $data  The data to check for emptiness.
      *
      * @return bool
      * @since TBD

--- a/tests/unit/tad/Codeception/SnapshotAssertions/DataSetNamingTest.php
+++ b/tests/unit/tad/Codeception/SnapshotAssertions/DataSetNamingTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace tad\Codeception\SnapshotAssertions;
+
+class DataSetNamingTest extends BaseTestCase
+{
+    use SnapshotAssertions;
+
+    /**
+     * @before
+     */
+    public function cleanUp()
+    {
+        $this->_after();
+    }
+
+    public static function stringSnapshotDataProvider()
+    {
+        return [
+            'snake_case_dataset' => ['snake_case', 'snake_case_dataset'],
+            'camelCaseDataset' => ['camelCase', 'camelCaseDataset'],
+            'PascalCaseDataset' => ['PascalCase', 'PascalCaseDataset'],
+            'kebab-case-dataset' => ['kebab-case', 'kebab-case-dataset'],
+            'spaces between words dataset' => ['spaces_between_words', 'spaces_between_words_dataset'],
+            'double  spaces  between  words  dataset' => ['double_spaces_between_words_dataset', 'double_spaces_between_words_dataset'],
+        ];
+    }
+
+    /**
+     * Should name snapshot files with slugs
+     *
+     * @test
+     * @dataProvider stringSnapshotDataProvider
+     */
+    public function should_name_snapshot_files_with_slugs($testString, $expected)
+    {
+        $expectedSnapshotFileName = __DIR__ . '/__snapshots__/DataSetNamingTest__should_name_snapshot_files_with_slugs__' . $expected . '__0.snapshot.txt';
+        $this->unlinkAfter[]= $expectedSnapshotFileName;
+
+        $this->assertMatchesStringSnapshot($testString);
+
+        $this->assertFileExists($expectedSnapshotFileName);
+    }
+}


### PR DESCRIPTION
Follows #21 to port the change to this version.

When building snapshot file names, convert spaces in data set names to `_`.
